### PR TITLE
Makefile will now process all files in "values" directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ dist/clusters/%.yml: values/%.yml
                       --snippets src/eu-west-1/snippets \
                       --values $< \
                       > $@
-	kops replace --force -f $@
-	kops update cluster
+	kops replace --force -f $@ --name $(patsubst dist/clusters/%.yml,%,$@)
+	kops update cluster --name $(patsubst dist/clusters/%.yml,%,$@)
 
 #
 # Targets

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,18 @@ dist/clusters/%.yml: values/%.yml
                       --snippets src/eu-west-1/snippets \
                       --values $< \
                       > $@
+	kops replace --force -f $@
+	kops update cluster
 
 #
 # Targets
 #
-build: $(CLUSTER_FILES)
+.PHONY: update test clean
+
+update: $(CLUSTER_FILES)
+
+test:
+	pre-commit run --all-files
 
 clean:
 	rm -rf $(CLUSTER_FILES)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ dist/clusters/%.yml: values/%.yml
 #
 # Targets
 #
-default: $(CLUSTER_FILES)
+build: $(CLUSTER_FILES)
 
 clean:
 	rm -rf $(CLUSTER_FILES)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
-.PHONY: test
-test:
-	pre-commit run --all-files
+# 
+# Variables
+#
+VALUE_FILES   = $(wildcard values/*.yml)
+CLUSTER_FILES = $(patsubst values/%,dist/clusters/%,$(VALUE_FILES))
 
+#
+# Rules
+#
 dist/clusters/%.yml: values/%.yml
 	kops toolbox template --fail-on-missing \
                       --format-yaml \
@@ -9,5 +14,11 @@ dist/clusters/%.yml: values/%.yml
                       --snippets src/eu-west-1/snippets \
                       --values $< \
                       > $@
-	kops replace --force -f $@
-	kops update cluster
+
+#
+# Targets
+#
+default: $(CLUSTER_FILES)
+
+clean:
+	rm -rf $(CLUSTER_FILES)

--- a/README.md
+++ b/README.md
@@ -19,15 +19,18 @@ You *always* have to set this environment variable.
 
 #### Automated installation
 
-  - It is possible to use `Makefile` target, for example:
+Run make and it will update all the clusters configured in the *values* directory
 
-  ```
-  make dist/clusters/cluster-exampleenv.yml
-  ```
-  Notice that this target assumes equality of `<cluster-name>`
-  between `dist/clusters/<cluster-name>.yml` and `values/<cluster-name>.yml`
+```
+make
+```
 
+For example the following values file will generate a cluster spec that will be used
+by kops to update the target cluster
 
+* values/cluster-exampleenv.yml
+
+The generated kops cluster specs will be found under the **dist/clusters** directory
 
 
 ##### Manual installation
@@ -44,7 +47,7 @@ kops toolbox template --fail-on-missing \
 
 * Generate a cluster from template:
 ```
-kops create -f clusters/cluster-exampleenv.yml
+kops create -f dist/clusters/cluster-exampleenv.yml
 ```
 
 


### PR DESCRIPTION
These changes make the automation more hands off

# Testing

Create two dummy files to represent 2 additional kops clusters
```
echo "" > values/demo1.k8s.local.yml
echo "" > values/demo2.k8s.local.yml
```

Demonstrate the commands generated by Make (Note the "--name" parameters being passed so that multiple clusters can be updated)

```
$ make --dry-run clean update
rm -rf dist/clusters/cluster-exampleenv.yml dist/clusters/demo1.k8s.local.yml dist/clusters/demo2.k8s.local.yml
kops toolbox template --fail-on-missing \
                      --format-yaml \
                      --template src/eu-west-1/templates \
                      --snippets src/eu-west-1/snippets \
                      --values values/cluster-exampleenv.yml \
                      > dist/clusters/cluster-exampleenv.yml
kops replace --force -f dist/clusters/cluster-exampleenv.yml --name cluster-exampleenv
kops update cluster --name cluster-exampleenv
kops toolbox template --fail-on-missing \
                      --format-yaml \
                      --template src/eu-west-1/templates \
                      --snippets src/eu-west-1/snippets \
                      --values values/demo1.k8s.local.yml \
                      > dist/clusters/demo1.k8s.local.yml
kops replace --force -f dist/clusters/demo1.k8s.local.yml --name demo1.k8s.local
kops update cluster --name demo1.k8s.local
kops toolbox template --fail-on-missing \
                      --format-yaml \
                      --template src/eu-west-1/templates \
                      --snippets src/eu-west-1/snippets \
                      --values values/demo2.k8s.local.yml \
                      > dist/clusters/demo2.k8s.local.yml
kops replace --force -f dist/clusters/demo2.k8s.local.yml --name demo2.k8s.local
kops update cluster --name demo2.k8s.local
```

Note:

* The additional "clean" target is useful to force an update of all clusters.